### PR TITLE
Windows portable distribution

### DIFF
--- a/components/databasemanager.cpp
+++ b/components/databasemanager.cpp
@@ -131,8 +131,12 @@ DatabaseManager::DatabaseManager()
     SettingsManager sm;
     QString dataDir = sm.restoreCustomDatabaseDir();
     if (dataDir.isEmpty()) { //use default
-        dataDir = QStandardPaths::standardLocations(
-                    QStandardPaths::DataLocation).at(0);
+        if (DefinitionHolder::WIN_PORTABLE) {
+            dataDir = "portable_data";
+        } else {
+            dataDir = QStandardPaths::standardLocations(
+                        QStandardPaths::DataLocation).at(0);
+        }
     }
     m_databaseName = "data.db";
     m_databasePath = dataDir.append("/");

--- a/components/settingsmanager.cpp
+++ b/components/settingsmanager.cpp
@@ -24,6 +24,10 @@
 SettingsManager::SettingsManager()
 {
     m_settings = new QSettings();
+
+    if (DefinitionHolder::WIN_PORTABLE) {
+        m_settings->setPath(QSettings::IniFormat, QSettings::UserScope, "portable_data");
+    }
 }
 
 SettingsManager::~SettingsManager()

--- a/components/settingsmanager.cpp
+++ b/components/settingsmanager.cpp
@@ -23,10 +23,10 @@
 
 SettingsManager::SettingsManager()
 {
-    m_settings = new QSettings();
-
     if (DefinitionHolder::WIN_PORTABLE) {
-        m_settings->setPath(QSettings::IniFormat, QSettings::UserScope, "portable_data");
+        m_settings = new QSettings("portable_data/settings.ini", QSettings::IniFormat);
+    } else {
+        m_settings = new QSettings();
     }
 }
 

--- a/components/sync_framework/syncengine.cpp
+++ b/components/sync_framework/syncengine.cpp
@@ -476,8 +476,14 @@ SyncEngine::SyncEngine(QObject *parent) :
     m_currentEngineOperation(NoSpecialOp),
     m_cloudSessionOpened(false)
 {
-    QString dataDir = QStandardPaths::standardLocations(
-                QStandardPaths::DataLocation).at(0);
+    QString dataDir;
+    if (DefinitionHolder::WIN_PORTABLE) {
+        dataDir = "portable_data";
+    } else {
+        dataDir = QStandardPaths::standardLocations(
+                    QStandardPaths::DataLocation).at(0);
+    }
+
     m_metadataFileName = "sync.meta";
     m_metadataFilePath = dataDir.append("/");
     m_metadataFilePath.append(m_metadataFileName);

--- a/doc/deployment/README
+++ b/doc/deployment/README
@@ -22,9 +22,14 @@ Prepare Dropbox SDK
 5. Copy dropbox_client.py and the dropbox folder to somewhere for later use
 
 Windows:
-1. Prepare dropbox client (windows exe) as described in "pyinstaller dropbox howto"
+1. Prepare dropbox client (windows exe) as described in "pyinstaller dropbox howto" or reuse from previous deployment (setup.exe)
 2. Open and compile symphytum.iss after review
 3. The missing .DLL files can be copied from the Qt install or use windeployqt
+
+Windows Portable:
+1. Follow similar steps as above
+2. Enable DefinitionHolder::WIN_PORTABLE before compiling to use local and portable storage directories
+3. Instead of running installer, just create a zip
 
 macOS:
 1. Use 'qmake -spec macx-clang Symphytum.pro' to generate Makefile

--- a/utils/definitionholder.cpp
+++ b/utils/definitionholder.cpp
@@ -26,7 +26,7 @@ int DefinitionHolder::SOFTWARE_BUILD = 7;
 int DefinitionHolder::DATABASE_VERSION = 2;
 bool DefinitionHolder::APP_STORE = false;
 bool DefinitionHolder::APPIMAGE_LINUX = false;
-bool DefinitionHolder::WIN_PORTABLE = false;
+bool DefinitionHolder::WIN_PORTABLE = true;
 QString DefinitionHolder::COPYRIGHT =
         QString("Copyright &copy; 2014-%1 Symphytum Developers"
                 "<br />Copyright &copy; 2012-2014 GIOWISYS Software UG (haftungsbeschr%2nkt)")

--- a/utils/definitionholder.cpp
+++ b/utils/definitionholder.cpp
@@ -26,6 +26,7 @@ int DefinitionHolder::SOFTWARE_BUILD = 7;
 int DefinitionHolder::DATABASE_VERSION = 2;
 bool DefinitionHolder::APP_STORE = false;
 bool DefinitionHolder::APPIMAGE_LINUX = false;
+bool DefinitionHolder::WIN_PORTABLE = false;
 QString DefinitionHolder::COPYRIGHT =
         QString("Copyright &copy; 2014-%1 Symphytum Developers"
                 "<br />Copyright &copy; 2012-2014 GIOWISYS Software UG (haftungsbeschr%2nkt)")

--- a/utils/definitionholder.cpp
+++ b/utils/definitionholder.cpp
@@ -26,7 +26,7 @@ int DefinitionHolder::SOFTWARE_BUILD = 7;
 int DefinitionHolder::DATABASE_VERSION = 2;
 bool DefinitionHolder::APP_STORE = false;
 bool DefinitionHolder::APPIMAGE_LINUX = false;
-bool DefinitionHolder::WIN_PORTABLE = true;
+bool DefinitionHolder::WIN_PORTABLE = false;
 QString DefinitionHolder::COPYRIGHT =
         QString("Copyright &copy; 2014-%1 Symphytum Developers"
                 "<br />Copyright &copy; 2012-2014 GIOWISYS Software UG (haftungsbeschr%2nkt)")

--- a/utils/definitionholder.h
+++ b/utils/definitionholder.h
@@ -34,6 +34,7 @@ public:
     static int DATABASE_VERSION;   /**< Version no. of the database        */
     static bool APP_STORE;         /**< Deployment target is an app store  */
     static bool APPIMAGE_LINUX;    /**< Deployment target is an AppImage   */
+    static bool WIN_PORTABLE;      /**< Deployment is portable Windows app */
 
 private:
     DefinitionHolder() {} //static only


### PR DESCRIPTION
Implement portable mode for Windows, see #51.
Data and settings are saved locally and are portable by just moving the "portable_data" directory over to new updated portable dist folders.